### PR TITLE
[bug fix]fix STU XVIII.ttf font reference

### DIFF
--- a/css/hex-long.css
+++ b/css/hex-long.css
@@ -1,6 +1,6 @@
 @font-face {
     font-family: "STU XVIII";
-    src: url(../font/STU XVIII.ttf);
+    src: url('../font/STU XVIII.ttf');
 }
 
 div.player div.name {


### PR DESCRIPTION
特典表示画面でSTUフォントが参照されず、鳥居マークが表示されない不具合を修正しました。

【原因】
```hex-long.css```内の```@font-face```でのフォントの相対path指定がアポストロフィで囲まれていなかった。

【対処】
フォントの相対path指定をアポストロフィで囲んだ。